### PR TITLE
Save embedded image with extension of embedded file

### DIFF
--- a/Version Control.accda.src/modules/clsDbSharedImage.bas
+++ b/Version Control.accda.src/modules/clsDbSharedImage.bas
@@ -57,8 +57,8 @@ Private Sub IDbComponent_Export()
     ' Save json file with header details
     WriteJsonFile TypeName(Me), dItem, IDbComponent_SourceFile, "Shared Image Gallery Item"
     
-    ' Save image file
-    strFile = IDbComponent_BaseFolder & FSO.GetBaseName(IDbComponent_SourceFile) & "." & m_Extension
+    ' Save image file using extension from embedded file.
+    strFile = IDbComponent_BaseFolder & FSO.GetBaseName(IDbComponent_SourceFile) & "." & FSO.GetExtensionName(m_FileName)
     Set stm = New ADODB.Stream
     With stm
         .Type = adTypeBinary
@@ -259,7 +259,7 @@ End Function
 '---------------------------------------------------------------------------------------
 '
 Private Sub IDbComponent_ClearOrphanedSourceFiles()
-    ClearOrphanedSourceFiles Me, "json", "jpg", "jpeg", "jpe", "gif", "png"
+    ClearOrphanedSourceFiles Me, "json", "jpg", "jpeg", "jpe", "gif", "png", "ico"
 End Sub
 
 


### PR DESCRIPTION
The actual extension of the embedded file may be different from the file extension column in the recordset. This change ensures that the import file name matches the exported file name. See #142